### PR TITLE
fix: GitHub runner label change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - "v*"
     branches:
        - main
-       - anssakthi/github-runner-fix
   schedule:
     - cron:  '30 4 * * *'  # Daily at 04:30 UTC
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - "v*"
     branches:
        - main
+       - anssakthi/github-runner-fix
   schedule:
     - cron:  '30 4 * * *'  # Daily at 04:30 UTC
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
   integration:
     name: "Integration tests (live Fluent)"
-    runs-on: [ubuntu-latest-8-cores]
+    runs-on: [public-ubuntu-latest-16-cores]
     needs: [smoke-tests]
     # if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:

--- a/doc/changelog.d/11.fixed.md
+++ b/doc/changelog.d/11.fixed.md
@@ -1,0 +1,1 @@
+GitHub runner label change


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by changing the runner used for integration tests to a more powerful machine.

