### PR TITLE
chore: bump PyFluent MCP dependencies

### DIFF
--- a/doc/changelog.d/31.maintenance.md
+++ b/doc/changelog.d/31.maintenance.md
@@ -1,0 +1,1 @@
+Bump PyFluent MCP dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-common-mcp>=0.3.2",
-    "ansys-fluent-core>=0.27",
+    "ansys-common-mcp>=0.3.3",
+    "ansys-fluent-core>=0.40.3",
     "httpx>=0.27",
     "pydantic>=2",
 ]
@@ -45,8 +45,8 @@ dependencies = [
 [project.optional-dependencies]
 file-probe = ["h5py>=3"]
 tests = [
-    "ansys-common-mcp>=0.3.2",
-    "ansys-fluent-core>=0.27",
+    "ansys-common-mcp==0.3.3",
+    "ansys-fluent-core==0.40.3",
     "httpx==0.28.1",
     "h5py==3.16.0",
     "pydantic==2.13.4",
@@ -54,7 +54,7 @@ tests = [
     "pytest-cov==7.1.0",
 ]
 doc = [
-    "ansys-common-mcp==0.3.2",
+    "ansys-common-mcp==0.3.3",
     "ansys-sphinx-theme[autoapi,changelog]==1.9.0",
     "httpx==0.28.1",
     "numpydoc==1.10.0",


### PR DESCRIPTION
## Description

Update PyFluent MCP dependencies to use the latest compatible PyFluent and PyAnsys Common MCP versions.

This PR updates:

- `ansys-fluent-core` to `0.40.3`
- `ansys-common-mcp` to `0.3.3`

The pinned versions in the `tests` and `doc` optional dependency groups are also updated so local development, CI, and documentation builds use the same dependency set.

## Motivation

PyFluent `0.40.2` can fail when connecting to an existing Fluent session using either `server_info_file_name` or explicit IP/port/password on Python 3.13. The traceback is wrapped as an `InvalidPassword` error, but the underlying issue is an API mismatch involving `application_runtime_pb2`.

Related upstream issue:

- https://github.com/ansys/pyfluent/issues/5282

Updating to `ansys-fluent-core==0.40.3` picks up the PyFluent-side fix for this connection workflow.


resolve: https://github.com/ansys/pyfluent-mcp/issues/32