### PR TITLE
fix: Resolve binary crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
     tags:
       - "v*"
     branches:
-       - main
+      - main
   schedule:
-    - cron:  '30 4 * * *'  # Daily at 04:30 UTC
+    - cron: "30 4 * * *" # Daily at 04:30 UTC
 
 permissions: {}
 
@@ -81,7 +81,7 @@ jobs:
         with:
           generate-summary: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          auditing-level: 'high'
+          auditing-level: "high"
 
   vulnerabilities:
     name: "Vulnerabilities"
@@ -89,13 +89,12 @@ jobs:
     permissions:
       contents: read # Needed to checkout the code
     steps:
-      - uses: ansys/actions/check-vulnerabilities@84b6533ae76f5dde69a1df26c18682160a8121cf #v10.3.5
+      - uses: ansys/actions/check-vulnerabilities@9dc4e3161033d2c2485fbf9687d40cfb7a661fb2 #v10.3.6
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
-
 
   smoke-tests:
     name: "Build and smoke tests"
@@ -107,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ["3.12", "3.13", "3.14"]
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -223,7 +222,7 @@ jobs:
     if: github.ref == 'refs/heads/main'  && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Needed to push documentation to gh-pages branch
+      contents: write # Needed to push documentation to gh-pages branch
     needs: [build-docs, package]
     steps:
       - name: "Deploy the latest documentation"
@@ -250,7 +249,6 @@ jobs:
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           maximum-pr-doc-deployments: 10
-
 
   release:
     name: "Release project"
@@ -284,7 +282,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Needed to push documentation to gh-pages branch
+      contents: write # Needed to push documentation to gh-pages branch
     needs: [release]
     steps:
       - name: "Deploy the stable documentation"
@@ -292,6 +290,6 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          render-last: '5'
+          render-last: "5"
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/doc/changelog.d/37.fixed.md
+++ b/doc/changelog.d/37.fixed.md
@@ -1,0 +1,1 @@
+Resolve binary crash

--- a/src/ansys/fluent/mcp/common/session_logging.py
+++ b/src/ansys/fluent/mcp/common/session_logging.py
@@ -70,6 +70,7 @@ not per-conversation event streams.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 import json
 import logging
 import os
@@ -444,11 +445,10 @@ def _gather_env_snapshot() -> str:
     lines.append(f"python: {sys.version.split()[0]}")
     lines.append(f"platform: {platform.platform()}")
     try:
-        import ansys.fluent.core as _pyfluent  # type: ignore
-
-        lines.append(f"pyfluent: {getattr(_pyfluent, '__version__', '?')}")
-    except Exception:
-        lines.append("pyfluent: <not importable>")
+        pyfluent_version = version("ansys-fluent-core")
+    except PackageNotFoundError:
+        pyfluent_version = "<not installed>"
+    lines.append(f"pyfluent: {pyfluent_version}")
     lines.append("")
     lines.append("# Environment variables")
     for key in sorted(os.environ):

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
 import json
 import logging
 
@@ -99,6 +100,65 @@ def test_env_snapshot_filters_and_redacts(monkeypatch):
     assert "ANSYS_TOKEN=<redacted len=12>" in snapshot
     assert "UNRELATED_SECRET" not in snapshot
     assert "pyfluent:" in snapshot
+
+
+def test_env_snapshot_uses_package_metadata_without_importing_pyfluent(monkeypatch):
+    """Verify that env snapshot reads PyFluent version without importing PyFluent.
+
+    Parameters
+    ----------
+    monkeypatch : Any
+        Pytest fixture used to patch environment variables or dependencies.
+
+    Returns
+    -------
+    None
+        The function completes through its side effects.
+    """
+    calls = []
+
+    def fake_version(name):
+        calls.append(name)
+        return "1.2.3"
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ansys.fluent.core" or name.startswith("ansys.fluent.core."):
+            raise AssertionError("env snapshot must not import ansys.fluent.core")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(session_logging, "version", fake_version)
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    snapshot = session_logging._gather_env_snapshot()
+
+    assert calls == ["ansys-fluent-core"]
+    assert "pyfluent: 1.2.3" in snapshot
+
+
+def test_env_snapshot_handles_missing_pyfluent_distribution(monkeypatch):
+    """Verify that env snapshot handles missing PyFluent distribution metadata.
+
+    Parameters
+    ----------
+    monkeypatch : Any
+        Pytest fixture used to patch environment variables or dependencies.
+
+    Returns
+    -------
+    None
+        The function completes through its side effects.
+    """
+
+    def missing_version(name):
+        raise session_logging.PackageNotFoundError(name)
+
+    monkeypatch.setattr(session_logging, "version", missing_version)
+
+    snapshot = session_logging._gather_env_snapshot()
+
+    assert "pyfluent: <not installed>" in snapshot
 
 
 def test_init_session_logging_creates_artifacts_and_is_idempotent(monkeypatch, tmp_path):


### PR DESCRIPTION
Resolve silent binary crash due to pyfluent import to check version. It is now being done using metadata instead of importing pyfluent directly.