### PR TITLE
ci: add Dependabot support for pre-commit hook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,20 @@ updates:
       actions:
         patterns:
           - "*"
+          
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "ansys/pre-commit-hooks"
+    labels:
+      - "maintenance"
+    commit-message:
+      prefix: "build(pre-commit)"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
       actions:
         patterns:
           - "*"
-          
+
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:

--- a/doc/changelog.d/40.maintenance.md
+++ b/doc/changelog.d/40.maintenance.md
@@ -1,0 +1,1 @@
+Add Dependabot support for pre-commit hook updates


### PR DESCRIPTION
Add Dependabot configuration to automatically monitor and update dependencies defined in .pre-commit-config.yaml.

This change enables automated pull requests whenever new versions of configured pre-commit hooks are available, helping keep the development tooling up to date with minimal manual intervention.

issue: https://github.com/ansys/pyfluent-mcp/issues/39