### PR TITLE
chore: bump development version to 0.4.dev0

### DIFF
--- a/doc/changelog.d/43.maintenance.md
+++ b/doc/changelog.d/43.maintenance.md
@@ -1,0 +1,1 @@
+Bump development version to 0.4.dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-fluent-mcp"
-version = "0.3.dev0"
+version = "0.4.dev0"
 description = "Model Context Protocol (MCP) server for ANSYS Fluent, built on PyFluent."
 readme = "README.md"
 requires-python = ">=3.12,<4"


### PR DESCRIPTION
This pull request updates the project version in `pyproject.toml` to reflect the next development cycle.

* Project version updated from `0.3.dev0` to `0.4.dev0` in `pyproject.toml` to mark the start of a new development iteration.